### PR TITLE
Add timer improvements and dark mode

### DIFF
--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,3 +1,58 @@
+/* Theme toggle button */
+.theme-toggle {
+	position: fixed;
+	top: 1rem;
+	right: 1rem;
+	z-index: 1000;
+	width: 3rem;
+	height: 3rem;
+	border-radius: 50%;
+	border: 2px solid var(--border);
+	background: var(--surface);
+	color: var(--text-main);
+	cursor: pointer;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+	transition: all 0.3s ease;
+	padding: 0;
+}
+
+.theme-toggle:hover {
+	transform: scale(1.1);
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+}
+
+.theme-toggle:active {
+	transform: scale(0.95);
+}
+
+.theme-icon {
+	width: 1.5rem;
+	height: 1.5rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.theme-icon svg {
+	width: 100%;
+	height: 100%;
+	transition: transform 0.3s ease;
+}
+
+.theme-toggle:hover .theme-icon svg {
+	transform: rotate(20deg);
+}
+
+.theme-icon.dark svg {
+	transform: rotate(-20deg);
+}
+
+.theme-toggle:hover .theme-icon.dark svg {
+	transform: rotate(0deg);
+}
 
 /* My Little Pony Themed Utility Classes */
 .pony-card {

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,3 +1,22 @@
+<button class="theme-toggle" (click)="toggleDarkMode()" [attr.aria-label]="isDarkMode() ? 'Switch to light mode' : 'Switch to dark mode'">
+  <span class="theme-icon" [class.dark]="isDarkMode()">
+    <svg *ngIf="!isDarkMode()" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <circle cx="12" cy="12" r="5"></circle>
+      <line x1="12" y1="1" x2="12" y2="3"></line>
+      <line x1="12" y1="21" x2="12" y2="23"></line>
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"></line>
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"></line>
+      <line x1="1" y1="12" x2="3" y2="12"></line>
+      <line x1="21" y1="12" x2="23" y2="12"></line>
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+    </svg>
+    <svg *ngIf="isDarkMode()" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+    </svg>
+  </span>
+</button>
+
 <app-title></app-title>
 <div class="container">
   <div class="toolbar">

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostListener, OnInit } from '@angular/core';
 import { TitleComponent } from './title/title.component';
 import { TimetableComponent } from './timetable/timetable.component';
 import { GroupSelectorComponent } from './group-selector/group-selector.component';
@@ -16,6 +16,53 @@ import { CommonModule } from '@angular/common';
   styleUrl: './app.css',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class App {
+export class App implements OnInit {
   selectedGroupId: string | null = null;
+  private keyBuffer = '';
+  private keyBufferTimeout: any;
+
+  ngOnInit(): void {
+    // Check if dark mode was previously enabled
+    const savedDarkMode = localStorage.getItem('darkMode');
+    if (savedDarkMode === 'true') {
+      document.body.classList.add('dark-mode');
+    }
+  }
+
+  @HostListener('window:keypress', ['$event'])
+  handleKeyPress(event: KeyboardEvent): void {
+    // Ignore if user is typing in an input field
+    const target = event.target as HTMLElement;
+    if (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA') {
+      return;
+    }
+
+    // Clear the previous timeout
+    if (this.keyBufferTimeout) {
+      clearTimeout(this.keyBufferTimeout);
+    }
+
+    // Add the key to the buffer
+    this.keyBuffer += event.key.toLowerCase();
+
+    // Check if the buffer ends with 'dm'
+    if (this.keyBuffer.endsWith('dm')) {
+      this.toggleDarkMode();
+      this.keyBuffer = '';
+    }
+
+    // Clear the buffer after 1 second of no typing
+    this.keyBufferTimeout = setTimeout(() => {
+      this.keyBuffer = '';
+    }, 1000);
+  }
+
+  toggleDarkMode(): void {
+    const isDark = document.body.classList.toggle('dark-mode');
+    localStorage.setItem('darkMode', isDark.toString());
+  }
+
+  isDarkMode(): boolean {
+    return document.body.classList.contains('dark-mode');
+  }
 }

--- a/src/app/timetable/timetable.component.css
+++ b/src/app/timetable/timetable.component.css
@@ -5,7 +5,21 @@
   color: var(--accent, #3a5ad7);
   background: #f0f2f7;
   border-radius: 8px;
-  margin: 1.2em auto 1em auto;
+  margin: 1.2em auto 0.5em auto;
+  padding: 0.6em 1.2em;
+  max-width: 340px;
+  font-weight: 600;
+  letter-spacing: 0.1px;
+}
+
+/* End of day timer styling */
+.end-of-day-timer {
+  text-align: center;
+  font-size: 1.12em;
+  color: #2d8659;
+  background: #e8f5ef;
+  border-radius: 8px;
+  margin: 0.5em auto 1em auto;
   padding: 0.6em 1.2em;
   max-width: 340px;
   font-weight: 600;
@@ -51,6 +65,11 @@
     padding: 0.8em 0.5em;
     max-width: 98vw;
   }
+  .end-of-day-timer {
+    font-size: 1.18em;
+    padding: 0.8em 0.5em;
+    max-width: 98vw;
+  }
 }
 
 @media (max-width: 400px) {
@@ -67,6 +86,10 @@
     min-height: 2em;
   }
   .next-break-timer {
+    font-size: 1.08em;
+    padding: 0.7em 0.2em;
+  }
+  .end-of-day-timer {
     font-size: 1.08em;
     padding: 0.7em 0.2em;
   }

--- a/src/app/timetable/timetable.component.css
+++ b/src/app/timetable/timetable.component.css
@@ -10,6 +10,12 @@
   max-width: 340px;
   font-weight: 600;
   letter-spacing: 0.1px;
+  transition: background 0.3s, color 0.3s;
+}
+
+:host-context(body.dark-mode) .next-break-timer {
+  background: #2a2b35 !important;
+  color: var(--accent) !important;
 }
 
 /* End of day timer styling */
@@ -24,6 +30,12 @@
   max-width: 340px;
   font-weight: 600;
   letter-spacing: 0.1px;
+  transition: background 0.3s, color 0.3s;
+}
+
+:host-context(body.dark-mode) .end-of-day-timer {
+  background: #2a2b35 !important;
+  color: #6dbf8f !important;
 }
 /* Responsive: single day view cells smaller for mobile */
 @media (max-width: 600px) {
@@ -139,6 +151,12 @@
   width: 98vw;
   max-width: 1200px;
   font-size: 1.08em;
+  transition: background 0.3s, border-color 0.3s, box-shadow 0.3s;
+}
+
+:host-context(body.dark-mode) .pony-timetable {
+  color: var(--text-main) !important;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.3) !important;
 }
 
 .pony-timetable th,
@@ -150,9 +168,14 @@
   color: #444;
   background: var(--surface, #fff);
   transition:
-    background 0.15s,
-    color 0.15s;
+    background 0.3s,
+    color 0.3s;
   touch-action: manipulation;
+}
+
+:host-context(body.dark-mode) .pony-timetable th,
+:host-context(body.dark-mode) .pony-timetable td {
+  color: var(--text-main) !important;
 }
 
 .pony-timetable th {
@@ -163,6 +186,10 @@
   border-bottom: 2px solid var(--border, #e0e3ea);
   position: relative;
   text-align: center;
+}
+
+:host-context(body.dark-mode) .pony-timetable th {
+  color: var(--text-main) !important;
 }
 
 .pony-timetable .class-chip {
@@ -176,9 +203,10 @@
   color: #555;
   position: relative;
   transition:
-    background 0.15s,
-    box-shadow 0.15s,
-    color 0.15s;
+    background 0.3s,
+    box-shadow 0.3s,
+    color 0.3s,
+    border-color 0.3s;
   min-height: 2.5em;
   display: flex;
   flex-direction: column;
@@ -186,21 +214,40 @@
   align-items: flex-start;
   touch-action: manipulation;
 }
+
+:host-context(body.dark-mode) .pony-timetable .class-chip {
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.3) !important;
+}
+
 .pony-timetable .class-chip:hover {
   background: #f0f2f7;
   color: var(--accent, #3a5ad7);
   box-shadow: 0 2px 8px 0 rgba(58, 90, 215, 0.1);
 }
 
+:host-context(body.dark-mode) .pony-timetable .class-chip:hover {
+  box-shadow: 0 2px 8px 0 rgba(107, 138, 255, 0.3) !important;
+}
+
 .pony-timetable .chip-subject {
   font-size: 1.08em;
   color: #444;
   font-family: "Segoe UI", "Roboto", Arial, sans-serif;
+  transition: color 0.3s;
+}
+
+:host-context(body.dark-mode) .pony-timetable .chip-subject {
+  color: #e8e9ed !important;
 }
 
 .pony-timetable .chip-meta {
   font-size: 0.97em;
   color: #444444;
+  transition: color 0.3s;
+}
+
+:host-context(body.dark-mode) .pony-timetable .chip-meta {
+  color: #c8c9d3 !important;
 }
 
 /* Stronger highlight for current day */
@@ -211,6 +258,13 @@
   border-bottom: 3px solid var(--accent, #3a5ad7);
   position: relative;
   z-index: 2;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s;
+}
+
+:host-context(body.dark-mode) .pony-timetable th.is-today {
+  background: #2d2e3a !important;
+  color: var(--accent) !important;
+  box-shadow: 0 2px 8px 0 rgba(107, 138, 255, 0.2) !important;
 }
 
 /* Stronger highlight for current period row */
@@ -222,6 +276,13 @@
   color: var(--accent, #3a5ad7);
   font-weight: 600;
   box-shadow: 0 2px 8px 0 rgba(58, 90, 215, 0.06);
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s;
+}
+
+:host-context(body.dark-mode) .pony-timetable tr.is-now-row > .period-col {
+  background: #2d2e3a !important;
+  color: var(--accent) !important;
+  box-shadow: 0 2px 8px 0 rgba(107, 138, 255, 0.2) !important;
 }
 
 .pony-timetable .cell.is-now {
@@ -232,15 +293,81 @@
   color: var(--accent, #3a5ad7);
   position: relative;
   z-index: 1;
+  transition: background 0.3s, color 0.3s, box-shadow 0.3s;
 }
+
+:host-context(body.dark-mode) .pony-timetable .cell.is-now {
+  background: #2d2e3a !important;
+  color: var(--accent) !important;
+  box-shadow: 0 2px 8px 0 rgba(107, 138, 255, 0.2) !important;
+}
+
 /* Subtle row and column hover for clarity */
 .pony-timetable tr:hover td {
   background: #f5f6fa;
 }
+
+:host-context(body.dark-mode) .pony-timetable tr:hover td {
+  background: #2a2b35 !important;
+}
+
 .pony-timetable td:hover {
   background: #f0f2f7;
   color: var(--accent, #3a5ad7);
 }
+
+:host-context(body.dark-mode) .pony-timetable td:hover {
+  background: #2d2e3a !important;
+  color: var(--accent) !important;
+}
+/* Single day toggle styling */
+.single-day-toggle {
+  color: var(--text-main);
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.3s;
+}
+
+.single-day-toggle input[type="checkbox"] {
+  margin-left: 0.5em;
+  cursor: pointer;
+}
+
+/* Muted text */
+.muted {
+  color: #999;
+  transition: color 0.3s;
+}
+
+:host-context(body.dark-mode) .muted {
+  color: #666 !important;
+}
+
+/* Period column styling */
+.period-col {
+  transition: background 0.3s, color 0.3s;
+}
+
+.period-title {
+  font-weight: 600;
+  color: var(--text-main);
+  transition: color 0.3s;
+}
+
+.period-time {
+  font-size: 0.9em;
+  color: var(--text-soft);
+  transition: color 0.3s;
+}
+
+/* Cell notes */
+.cell-notes {
+  font-size: 0.85em;
+  color: var(--text-soft);
+  margin-top: 0.3em;
+  transition: color 0.3s;
+}
+
 /* existing styles ... */
 
 /* Remove old pony/primary highlights for Hello Kitty theme */

--- a/src/app/timetable/timetable.component.html
+++ b/src/app/timetable/timetable.component.html
@@ -62,7 +62,7 @@
             <div
               class="class-chip"
               [ngStyle]="{
-                'background-color': c.color,
+                'background-color': adjustColorForDarkMode(c.color),
                 color: textColorFor(c.color),
               }"
               title="{{ c.teacher }}{{ c.room ? ' · ' + c.room : '' }}"

--- a/src/app/timetable/timetable.component.html
+++ b/src/app/timetable/timetable.component.html
@@ -1,9 +1,15 @@
 <div class="timetable-fullscreen">
   <div
-    *ngIf="nextBreakMinutes !== null && nextBreakMinutes > 0"
+    *ngIf="nextBreakMinutes !== null && nextBreakMinutes >= 0 && nextBreakSeconds !== null"
     class="next-break-timer"
   >
-    <span>הפסקה בעוד {{ nextBreakMinutes }} דקות ({{ nextBreakLabel }})</span>
+    <span>הפסקה בעוד {{ nextBreakMinutes }}:{{ nextBreakSeconds < 10 ? '0' + nextBreakSeconds : nextBreakSeconds }} ({{ nextBreakLabel }})</span>
+  </div>
+  <div
+    *ngIf="endOfDayHours !== null && endOfDayMinutes !== null && endOfDaySeconds !== null"
+    class="end-of-day-timer"
+  >
+    <span>סוף יום בעוד {{ endOfDayHours }}:{{ endOfDayMinutes < 10 ? '0' + endOfDayMinutes : endOfDayMinutes }}:{{ endOfDaySeconds < 10 ? '0' + endOfDaySeconds : endOfDaySeconds }}</span>
   </div>
   <div style="margin-bottom: 1em; text-align: right">
     <label class="single-day-toggle">

--- a/src/app/timetable/timetable.component.ts
+++ b/src/app/timetable/timetable.component.ts
@@ -198,11 +198,17 @@ export class TimetableComponent implements OnChanges, OnInit, OnDestroy {
       return;
     }
 
-    // Find the next break period after the current period
+    // Find the next break period after the current period (only scheduled breaks)
     let nextBreakStart: number | null = null;
     let nextBreakLabel: string | null = null;
     for (let i = currentIdx + 1; i < todayRows.length; ++i) {
       const row = todayRows[i];
+
+      // Skip periods not scheduled for today
+      if (row.cells[this.nowDay] === null) {
+        continue;
+      }
+
       // Heuristic: break if periodId starts with 'B', or title/name includes 'break' or 'הפסקה', or if all cells for this row have subject 'הפסקה' or classId 'BREAK'
       const isBreak =
         /^B\d+$/i.test(row.periodId) || /break|הפסקה/i.test(row.title);
@@ -428,6 +434,32 @@ export class TimetableComponent implements OnChanges, OnInit, OnDestroy {
       b = parseInt(full.slice(4, 6), 16);
     const yiq = (r * 299 + g * 587 + b * 114) / 1000;
     return yiq >= 128 ? '#000' : '#fff';
+  }
+
+  /** Adjust color for dark mode - mute bright colors and ensure readability */
+  adjustColorForDarkMode(color: string): string {
+    if (!document.body.classList.contains('dark-mode')) {
+      return color;
+    }
+
+    const hex = color.replace('#', '');
+    const full =
+      hex.length === 3
+        ? hex.split('').map((c) => c + c).join('')
+        : hex.padEnd(6, '0').slice(0, 6);
+
+    let r = parseInt(full.slice(0, 2), 16);
+    let g = parseInt(full.slice(2, 4), 16);
+    let b = parseInt(full.slice(4, 6), 16);
+
+    // Reduce saturation and brightness for dark mode
+    // Convert to HSL-like adjustment
+    const factor = 0.6; // Mute factor
+    r = Math.floor(r * factor);
+    g = Math.floor(g * factor);
+    b = Math.floor(b * factor);
+
+    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`;
   }
 
   /** True if this cell is the current lesson */

--- a/src/app/title/title.component.css
+++ b/src/app/title/title.component.css
@@ -5,8 +5,12 @@
 	font-style: italic;
 	text-align: center;
 	letter-spacing: 0.1px;
+	transition: color 0.3s;
 }
 
+body.dark-mode .daily-quote {
+	color: var(--text-soft);
+}
 
 .pony-title {
 	font-family: 'Segoe UI', 'Roboto', Arial, sans-serif;
@@ -16,4 +20,5 @@
 	letter-spacing: 0.5px;
 	margin-bottom: 0.5em;
 	padding-bottom: 0.1em;
+	transition: color 0.3s;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -15,6 +15,18 @@
 	--shadow: 0 2px 16px 0 rgba(35,36,58,0.06);
 }
 
+/* Dark Mode Theme */
+body.dark-mode {
+	--primary: #e8e9ed;
+	--accent: #6b8aff;
+	--background: #1a1b26;
+	--surface: #24252f;
+	--border: #3a3b45;
+	--text-main: #e8e9ed;
+	--text-soft: #a0a1ab;
+	--shadow: 0 2px 16px 0 rgba(0,0,0,0.3);
+}
+
 body {
 	min-height: 100vh;
 	margin: 0;
@@ -22,7 +34,7 @@ body {
 	background: var(--background);
 	color: var(--text-main);
 	box-sizing: border-box;
-	transition: background 0.5s;
+	transition: background 0.3s, color 0.3s;
 	direction: rtl;
 }
 


### PR DESCRIPTION
## Summary
- Add seconds display to break timer and end-of-day countdown for more precise timing
- Fix break timer to show remaining time when currently in a break
- Fix end-of-day timer to only count scheduled class periods (excluding breaks and unscheduled periods)
- Implement comprehensive dark mode with dual toggle methods
- Add floating theme toggle button with sun/moon icons

## Features

### Timer Improvements
- Break timer now displays seconds in addition to minutes
- End-of-day timer shows hours, minutes, and seconds
- Fixed break timer to properly handle current break periods
- Fixed end-of-day timer to exclude unscheduled template periods

### Dark Mode
- **Keyboard shortcut**: Type "dm" anywhere to toggle dark mode
- **Visual toggle**: Floating button in top-right corner with sun/moon icons
- Muted subject box colors in dark mode for better readability
- All UI elements properly styled for dark mode (timers, tables, headers, hover states, etc.)
- Preference saved to localStorage
- Smooth transitions between themes

## Test Plan
- [x] Verify break timer shows seconds
- [x] Verify end-of-day timer shows hours:minutes:seconds
- [x] Test break timer during an actual break period
- [x] Verify end-of-day timer only counts scheduled periods
- [x] Toggle dark mode via "dm" keyboard shortcut
- [x] Toggle dark mode via floating button
- [x] Verify all UI elements are properly styled in both modes
- [x] Check that dark mode preference persists on page reload